### PR TITLE
Add seed() API for reproducible RNG streams

### DIFF
--- a/cpp/include/Distribution.h
+++ b/cpp/include/Distribution.h
@@ -16,6 +16,16 @@ class CRNGWrapper
 public:
 	double rand();
 	double norm();
+
+	/// Seed the process-wide Mersenne Twister generator.
+	/// If never called, the generator is seeded from std::random_device
+	/// at library load time (non-reproducible). Calling seed() makes
+	/// subsequent random output deterministic for the given seed value.
+	/// In multiprocessing contexts (spawn start method), each worker
+	/// process has its own copy of the static generator, so calling
+	/// seed(master_seed + worker_id) in each worker produces independent
+	/// reproducible streams.
+	static void seed(uint64_t s);
 };
 
 class CDistribution  

--- a/cpp/src/Distribution.cpp
+++ b/cpp/src/Distribution.cpp
@@ -14,7 +14,16 @@ std::normal_distribution<double> CRNGWrapper::m_Norm(0.0,1.0);
 //std::mt19937 CRNGWrapper::m_MTgen(100); // MAGIC NUMBER - constant seed for debugging
 std::mt19937 CRNGWrapper::m_MTgen(std::random_device{}());
 
-inline double CRNGWrapper::rand() 
+void CRNGWrapper::seed(uint64_t s)
+{
+	m_MTgen.seed(s);
+	// Reset the distributions so they don't carry cached state from
+	// the previous seed.
+	m_Uniform.reset();
+	m_Norm.reset();
+}
+
+inline double CRNGWrapper::rand()
 {
 	return m_Uniform(m_MTgen);
 };

--- a/cpp/src/py_main.cpp
+++ b/cpp/src/py_main.cpp
@@ -2,6 +2,7 @@
 // the main file for the PyBTLS Build
 
 #include "PrepareSim.h"
+#include "Distribution.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 #include "pybind11/stl/filesystem.h"
@@ -19,6 +20,30 @@ PYBIND11_MODULE(libbtls, m) {
 		m.attr("__version__") = "dev";
 	#endif
 	m.def("get_info", &preamble, "Print the information of the BTLS library.");
+	m.def("_sample_uniform", []() {
+		CDistribution d;
+		return d.GenerateUniform();
+	}, "Internal test helper: draw one uniform [0,1) sample from the process-wide RNG.");
+	m.def("seed", &CRNGWrapper::seed,
+		R"(
+		Seed the process-wide random number generator.
+
+		If never called, the generator is seeded non-deterministically at
+		library load time (the default behaviour). Calling seed() makes all
+		subsequent traffic generation and sampling deterministic for the
+		given value.
+
+		In multiprocessing contexts (spawn start method), each worker
+		process has its own copy of the generator, so calling
+		``seed(master_seed + worker_id)`` in each worker produces
+		independent, reproducible streams.
+
+		Parameters
+		----------
+		s : int
+			Seed value (unsigned 64-bit integer).
+		)",
+		py::arg("s"));
 	m.def("run", &run, 
 		R"(
 		Run the simulation in the traditional BTLS way. 

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,125 @@
+"""
+Tests for the CRNGWrapper::seed() API.
+
+Verifies:
+1. Seeding produces reproducible output (same seed → same sequence).
+2. Different seeds produce different output.
+3. Unseeded (default) runs produce different output across spawned
+   processes (since each spawned process re-seeds from std::random_device).
+"""
+
+import multiprocessing
+import pytest
+from pybtls.lib import libbtls
+
+
+N_SAMPLES = 20  # number of RNG draws per test
+
+
+def _draw_samples(n=N_SAMPLES):
+    """Draw n uniform samples from the process-wide C++ RNG."""
+    return [libbtls._sample_uniform() for _ in range(n)]
+
+
+def _draw_seeded_in_subprocess(seed_val):
+    """Spawned-process helper: seed, draw, return the samples."""
+    from pybtls.lib import libbtls
+    if seed_val is not None:
+        libbtls.seed(seed_val)
+    return [libbtls._sample_uniform() for _ in range(N_SAMPLES)]
+
+
+# -----------------------------------------------------------------------
+# API surface tests
+# -----------------------------------------------------------------------
+
+class TestSeedAPI:
+    def test_seed_callable(self):
+        libbtls.seed(42)
+
+    def test_seed_accepts_large_values(self):
+        libbtls.seed(2**63 - 1)
+
+    def test_seed_zero(self):
+        libbtls.seed(0)
+
+    def test_seed_docstring(self):
+        assert "reproducible" in libbtls.seed.__doc__.lower()
+
+
+# -----------------------------------------------------------------------
+# Reproducibility tests (same process)
+# -----------------------------------------------------------------------
+
+class TestSeedReproducibility:
+    def test_same_seed_same_output(self):
+        """seed(X) → draw N → seed(X) → draw N: both sequences must match."""
+        libbtls.seed(42)
+        seq_a = _draw_samples()
+
+        libbtls.seed(42)
+        seq_b = _draw_samples()
+
+        assert seq_a == seq_b, "Same seed must produce identical sequences"
+
+    def test_different_seed_different_output(self):
+        """seed(X) and seed(Y) with X≠Y must produce different sequences."""
+        libbtls.seed(42)
+        seq_a = _draw_samples()
+
+        libbtls.seed(99)
+        seq_b = _draw_samples()
+
+        assert seq_a != seq_b, "Different seeds must produce different sequences"
+
+    def test_reseed_resets_stream(self):
+        """Drawing after a reseed should restart the stream, not continue it."""
+        libbtls.seed(123)
+        first_val = libbtls._sample_uniform()
+        # Draw a bunch more to advance the stream
+        _draw_samples(100)
+        # Reseed to the same value
+        libbtls.seed(123)
+        restarted_val = libbtls._sample_uniform()
+
+        assert first_val == restarted_val, "Reseed must restart the stream"
+
+
+# -----------------------------------------------------------------------
+# Cross-process independence tests (multiprocessing with spawn)
+# -----------------------------------------------------------------------
+
+class TestSpawnedProcessIndependence:
+    def test_unseeded_processes_differ(self):
+        """Two spawned processes without explicit seed should produce
+        different sequences (with overwhelming probability, since each
+        gets a fresh std::random_device seed)."""
+        ctx = multiprocessing.get_context("spawn")
+        with ctx.Pool(2) as pool:
+            results = pool.map(_draw_seeded_in_subprocess, [None, None])
+
+        assert results[0] != results[1], (
+            "Unseeded spawned processes should get different RNG streams"
+        )
+
+    def test_same_seed_across_processes(self):
+        """Two spawned processes seeded with the same value must produce
+        identical sequences (proves the seed propagates into the C++ RNG)."""
+        ctx = multiprocessing.get_context("spawn")
+        with ctx.Pool(2) as pool:
+            results = pool.map(_draw_seeded_in_subprocess, [42, 42])
+
+        assert results[0] == results[1], (
+            "Same seed in different processes must produce identical sequences"
+        )
+
+    def test_different_seeds_across_processes(self):
+        """Two spawned processes seeded with different values must produce
+        different sequences."""
+        ctx = multiprocessing.get_context("spawn")
+        with ctx.Pool(2) as pool:
+            results = pool.map(_draw_seeded_in_subprocess, [42, 99])
+
+        assert results[0] != results[1], (
+            "Different seeds in different processes must produce different sequences"
+        )


### PR DESCRIPTION
## Summary

- Add `CRNGWrapper::seed(uint64_t)` — one static method that reseeds the process-wide Mersenne Twister and resets cached distribution state
- Expose as `pybtls.lib.libbtls.seed(s)` via pybind11 with a NumPy-style docstring
- Add `_sample_uniform()` test helper for direct RNG verification
- **Fully backwards compatible**: if `seed()` is never called, behaviour is identical to today (non-deterministic `random_device` seed at library load)

## Usage

```python
# Reproducible single run:
import pybtls
pybtls.lib.libbtls.seed(42)
sim.run()  # same result every time

# Day-parallel (each worker is a separate process):
def run_chunk(args):
    master_seed, day_start = args
    pybtls.lib.libbtls.seed(master_seed + day_start)
    # run sim for this day range
```

## Test plan

- [x] 10 pytest tests covering API surface, in-process reproducibility, cross-process independence (all pass, ~1.3s)
- [x] Standalone BTLS binary builds clean (`cmake -DBinary=ON`)
- [x] PyBTLS extension builds and imports (`pip install -e .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)