### PR TITLE
fix(deps): pin scipy<1.17 to fix CI wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "matplotlib",
     "numpy",
     "pandas>=1.5,<2.3",
-    "scipy"
+    "scipy>=1.10,<1.17"
 ]
 
 [project.urls]


### PR DESCRIPTION
scipy 1.17.1 tries to build from source on manylinux2014 and fails because OpenBLAS is not installed in the CI container. Pin to <1.17 so pip installs 1.16.x which has pre-built manylinux2014 wheels.

Same root cause as the pandas pin — the manylinux2014 image's toolchain is too old for the latest meson-based builds. Both pins can be relaxed when CI migrates to manylinux_2_28 or newer.